### PR TITLE
Velocity Tracking

### DIFF
--- a/src/main/java/boomcow/minezero/checkpoint/CheckpointManager.java
+++ b/src/main/java/boomcow/minezero/checkpoint/CheckpointManager.java
@@ -23,6 +23,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.Vec3;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -54,6 +55,12 @@ public class CheckpointManager {
             pdata.yaw = player.getYRot();
             pdata.pitch = player.getXRot();
             pdata.dimension = player.level().dimension(); // Save dimension
+
+            // Using player.getDeltaMovement() which returns a Vec3
+            pdata.motionX = player.getDeltaMovement().x;
+            pdata.motionY = player.getDeltaMovement().y;
+            pdata.motionZ = player.getDeltaMovement().z;
+            pdata.fallDistance = player.fallDistance;
 
             // Store health, hunger, xp
             pdata.health = player.getHealth();
@@ -274,11 +281,13 @@ public class CheckpointManager {
                     }
 
                     // Restore health, hunger, xp, fire ticks
-
                     player.getFoodData().setFoodLevel(pdata.hunger);
                     player.setExperiencePoints(pdata.xp);
                     player.setRemainingFireTicks(pdata.fireTicks);
 //                    logger.info("remaining fire ticks: " + pdata.fireTicks);
+
+                    player.setDeltaMovement(new Vec3(pdata.motionX, pdata.motionY, pdata.motionZ));
+                    player.fallDistance = pdata.fallDistance;
 
                     // Restore potion effects
                     player.removeAllEffects();

--- a/src/main/java/boomcow/minezero/checkpoint/PlayerData.java
+++ b/src/main/java/boomcow/minezero/checkpoint/PlayerData.java
@@ -16,6 +16,10 @@ public class PlayerData {
     public double posX;
     public double posY;
     public double posZ;
+    public double motionX;
+    public double motionY;
+    public double motionZ;
+    public float fallDistance;
     public float yaw;
     public float pitch;
     public float health;
@@ -34,6 +38,10 @@ public class PlayerData {
         tag.putDouble("PosX", posX);
         tag.putDouble("PosY", posY);
         tag.putDouble("PosZ", posZ);
+        tag.putDouble("MotionX", motionX);
+        tag.putDouble("MotionY", motionY);
+        tag.putDouble("MotionZ", motionZ);
+        tag.putFloat("FallDistance", fallDistance);
         tag.putFloat("Yaw", yaw);
         tag.putFloat("Pitch", pitch);
         tag.putFloat("Health", health);
@@ -78,6 +86,10 @@ public class PlayerData {
         data.posX = tag.getDouble("PosX");
         data.posY = tag.getDouble("PosY");
         data.posZ = tag.getDouble("PosZ");
+        data.fallDistance = tag.getFloat("FallDistance");
+        data.motionX = tag.getDouble("MotionX");
+        data.motionY = tag.getDouble("MotionY");
+        data.motionZ = tag.getDouble("MotionZ");
         data.yaw = tag.getFloat("Yaw");
         data.pitch = tag.getFloat("Pitch");
         data.health = tag.getFloat("Health");


### PR DESCRIPTION
# PR#9

## Type of Changes

- [x] Bug fix

## Description

This PR resolves the issue where knockback, acceleration, and velocity were not being properly cached and restored during a rollback. The changes include:

- **PlayerData Enhancements:**  
  Added new fields (`accelX`, `accelY`, and `accelZ`) to store the player's acceleration or knockback state.

- **Checkpoint Capture Logic:**  
  Updated the checkpointing process in `CheckpointManager.setCheckpoint` to capture and conditionally preserve acceleration values. When a player is mid-air (i.e. not on the ground), the previous checkpoint's acceleration values are preserved to prevent resetting the acceleration state through spamming.

- **Rollback Restoration:**  
  During rollback, the player's movement state (position, velocity, fall distance, and now acceleration) is restored exactly as it was at the last valid checkpoint, ensuring that knockback or unwanted velocity effects from mobs do not persist.

These changes ensure that the player's movement state is consistent with the last saved checkpoint, preventing exploits and unintended behavior.

## How has this been tested?

1. **Falling Scenario:**  
   - Start falling from a high place.
   - Set a checkpoint mid-air using the Artifact Flute.
   - Spam the Artifact Flute while falling to verify that the acceleration values are not reset.

2. **Knockback Scenario:**  
   - While falling, get hit by a mob to receive knockback.
   - Die to trigger a rollback.
   - Confirm that upon rollback, the player's velocity and acceleration are restored to the checkpoint state and that the knockback from the mob does not persist.

## Additional Information

- This PR resolves #9.
