### PR TITLE
1.20.1 forge

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -104,7 +104,6 @@ repositories {
         name = "Jared's maven"
         url = "https://maven.blamejared.com"
     }
-
 }
 
 dependencies {
@@ -126,7 +125,6 @@ dependencies {
     compileOnly(fg.deobf("mezz.jei:jei-${mc_version}-forge-api:${jei_version}"))
     // at runtime, use the full JEI jar for Forge
     runtimeOnly(fg.deobf("mezz.jei:jei-${mc_version}-forge:${jei_version}"))
-
     // For more info...
     // http://www.gradle.org/docs/current/userguide/artifact_dependencies_tutorial.html
     // http://www.gradle.org/docs/current/userguide/dependency_management.html

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,4 +4,4 @@ org.gradle.daemon=false
 mc_version=1.20.1
 jei_version=15.2.0.27
 
-minezero_version=1.0.9
+minezero_version=1.0.10

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,4 +4,4 @@ org.gradle.daemon=false
 mc_version=1.20.1
 jei_version=15.2.0.27
 
-minezero_version=1.0.8
+minezero_version=1.0.9

--- a/src/main/java/boomcow/minezero/MineZero.java
+++ b/src/main/java/boomcow/minezero/MineZero.java
@@ -152,7 +152,12 @@ public class MineZero {
         if (data.getAnchorPlayerUUID() == null && data.getPlayerData(player.getUUID()) == null) {
             LOGGER.info("[MineZero][LOGIN] No anchor player set and player {} is new to checkpoint. Setting initial checkpoint for this player.", player.getName().getString());
             // This will set the current player as the anchor and save their state, effectively creating the first checkpoint.
-            CheckpointManager.setCheckpoint(player);
+
+            // set if gamerule SET_CHECKPOINT_ON_WORLD_CREATION is true
+            if (player.level().getGameRules().getBoolean(ModGameRules.SET_CHECKPOINT_ON_WORLD_CREATION)) {
+                CheckpointManager.setCheckpoint(player);
+            }
+
             // data.setAnchorPlayerUUID(player.getUUID()); // setCheckpoint already does this
             // data.setDirty(); // setCheckpoint calls savePlayerData which calls setDirty
             LOGGER.info("[MineZero][LOGIN] 🎯 Initial anchor and checkpoint set for {}", player.getName().getString());

--- a/src/main/java/boomcow/minezero/MineZero.java
+++ b/src/main/java/boomcow/minezero/MineZero.java
@@ -151,15 +151,12 @@ public class MineZero {
         // AND no checkpoint data exists for this player yet (which would be true if they are the first)
         if (data.getAnchorPlayerUUID() == null && data.getPlayerData(player.getUUID()) == null) {
             LOGGER.info("[MineZero][LOGIN] No anchor player set and player {} is new to checkpoint. Setting initial checkpoint for this player.", player.getName().getString());
-            // This will set the current player as the anchor and save their state, effectively creating the first checkpoint.
 
             // set if gamerule SET_CHECKPOINT_ON_WORLD_CREATION is true
             if (player.level().getGameRules().getBoolean(ModGameRules.SET_CHECKPOINT_ON_WORLD_CREATION)) {
                 CheckpointManager.setCheckpoint(player);
             }
 
-            // data.setAnchorPlayerUUID(player.getUUID()); // setCheckpoint already does this
-            // data.setDirty(); // setCheckpoint calls savePlayerData which calls setDirty
             LOGGER.info("[MineZero][LOGIN] 🎯 Initial anchor and checkpoint set for {}", player.getName().getString());
         }
         // Scenario 2: An anchor player IS set, but THIS player logging in does not have data in the current checkpoint

--- a/src/main/java/boomcow/minezero/ModGameRules.java
+++ b/src/main/java/boomcow/minezero/ModGameRules.java
@@ -32,4 +32,8 @@ public class ModGameRules {
     // New gamerule to enable/disable the Artifact Flute entirely
     public static final GameRules.Key<BooleanValue> ARTIFACT_FLUTE_ENABLED =
             GameRules.register("artifactFluteEnabled", GameRules.Category.PLAYER, GameRules.BooleanValue.create(true));
+
+    // gamerule to enable setting checkpoint on world creation
+    public static final GameRules.Key<BooleanValue> SET_CHECKPOINT_ON_WORLD_CREATION =
+            GameRules.register("setCheckpointOnWorldCreation", GameRules.Category.PLAYER, GameRules.BooleanValue.create(true));
 }

--- a/src/main/java/boomcow/minezero/event/BlockEntityChangeListener.java
+++ b/src/main/java/boomcow/minezero/event/BlockEntityChangeListener.java
@@ -1,0 +1,109 @@
+package boomcow.minezero.event;
+
+import boomcow.minezero.checkpoint.CheckpointData;
+import boomcow.minezero.checkpoint.WorldData;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.level.block.ChestBlock;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.ChestBlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+import net.minecraftforge.eventbus.api.EventPriority;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+@Mod.EventBusSubscriber
+public class BlockEntityChangeListener {
+
+    private static final Logger LOGGER_BECL = LogManager.getLogger("MineZeroBECL");
+
+    private static WorldData getActiveWorldData(ServerLevel level) {
+        // ... (this helper method is fine as is)
+        if (level == null || level.getServer() == null) {
+            return null;
+        }
+        CheckpointData checkpointData = CheckpointData.get(level);
+        if (checkpointData != null && checkpointData.getAnchorPlayerUUID() != null) {
+            return checkpointData.getWorldData();
+        }
+        return null;
+    }
+
+    @SubscribeEvent(priority = EventPriority.HIGHEST) // Keep HIGHEST priority, it's good practice
+    public static void onPlayerInteractWithBlockEntity(PlayerInteractEvent.RightClickBlock event) {
+        if (event.getLevel().isClientSide() || !(event.getEntity() instanceof ServerPlayer player)) {
+            return;
+        }
+
+        ServerLevel level = player.serverLevel();
+        WorldData worldData = getActiveWorldData(level);
+
+        if (worldData == null) {
+            return;
+        }
+
+        BlockPos pos = event.getPos();
+        BlockEntity blockEntity = level.getBlockEntity(pos);
+
+        if (blockEntity == null) {
+            return;
+        }
+
+        // --- NEW LOGIC FOR DOUBLE CHESTS ---
+        if (blockEntity instanceof ChestBlockEntity) {
+            BlockState blockState = level.getBlockState(pos);
+            if (blockState.getBlock() instanceof ChestBlock) {
+                // Get the direction of the other half of the chest. This returns null if there is no other half.
+                Direction connectedDirection = ChestBlock.getConnectedDirection(blockState);
+
+                if (connectedDirection != null) {
+                    BlockPos otherChestPos = pos.relative(connectedDirection);
+                    BlockEntity otherBlockEntity = level.getBlockEntity(otherChestPos);
+                    if (otherBlockEntity instanceof ChestBlockEntity) {
+                        // We found the other half. Cache it if it's not already cached.
+                        LOGGER_BECL.debug("Detected double chest. Caching other half at {}.", otherChestPos);
+                        cacheBlockEntityState(otherChestPos, otherBlockEntity, worldData, level);
+                    }
+                }
+            }
+        }
+        // --- END OF NEW LOGIC ---
+
+        // Now, cache the state of the block that was actually clicked.
+        // The helper function will handle the check and logging.
+        cacheBlockEntityState(pos, blockEntity, worldData, level);
+    }
+
+    /**
+     * Helper function to cache the state of a single BlockEntity if it hasn't been cached yet.
+     * This avoids code duplication and makes the main listener cleaner.
+     *
+     * @param pos The position of the BlockEntity.
+     * @param blockEntity The BlockEntity instance.
+     * @param worldData The active WorldData.
+     * @param level The level the BlockEntity is in.
+     */
+    private static void cacheBlockEntityState(BlockPos pos, BlockEntity blockEntity, WorldData worldData, ServerLevel level) {
+        // Use an immutable position for map keys to ensure safety
+        BlockPos immutablePos = pos.immutable();
+
+        // Check if this specific block's state is already cached.
+        if (worldData.getBlockEntityData().containsKey(immutablePos)) {
+            return; // Already handled, do nothing.
+        }
+
+        LOGGER_BECL.info("First interaction with BlockEntity at {} post-checkpoint. Caching its state.", immutablePos);
+
+        // Save the full NBT data of the block entity
+        worldData.saveBlockEntity(immutablePos, blockEntity.saveWithFullMetadata());
+        LOGGER_BECL.debug("Successfully saved BlockEntity data for {}. NBT: {}", immutablePos, blockEntity.saveWithFullMetadata().toString());
+
+        // Also save its dimension index so it can be restored correctly
+        worldData.getInstanceBlockDimensionIndices().put(immutablePos, WorldData.getDimensionIndex(level.dimension()));
+    }
+}

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -19,7 +19,7 @@ modId="minezero" #mandatory
 # The version number of the mod - there's a few well known ${} variables useable here or just hardcode it
 # ${file.jarVersion} will substitute the value of the Implementation-Version as read from the mod's JAR file metadata
 # see the associated build.gradle script for how to populate this completely automatically during a build
-version="1.0.8" #mandatory
+version="1.0.9" #mandatory
 # A display name for the mod
 displayName="MineZero" #mandatory
 # A URL to query for updates for this mod. See the JSON update specification https://docs.minecraftforge.net/en/latest/misc/updatechecker/

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -19,7 +19,7 @@ modId="minezero" #mandatory
 # The version number of the mod - there's a few well known ${} variables useable here or just hardcode it
 # ${file.jarVersion} will substitute the value of the Implementation-Version as read from the mod's JAR file metadata
 # see the associated build.gradle script for how to populate this completely automatically during a build
-version="1.0.9" #mandatory
+version="1.0.10" #mandatory
 # A display name for the mod
 displayName="MineZero" #mandatory
 # A URL to query for updates for this mod. See the JSON update specification https://docs.minecraftforge.net/en/latest/misc/updatechecker/

--- a/src/main/resources/assets/minezero/lang/en_us.json
+++ b/src/main/resources/assets/minezero/lang/en_us.json
@@ -25,6 +25,9 @@
   "gamerule.artifactFluteEnabled": "Artifact Flute Enabled",
   "gamerule.artifactFluteEnabled.description": "Enable or disable the Artifact Flute feature.",
 
+  "gamerule.setCheckpointOnWorldCreation":" Set Checkpoint on World Creation",
+  "gamerule.setCheckpointOnWorldCreation.description": "Automatically set a checkpoint when a new world is created.",
+
   "_comment": "Keybinds",
   "key.categories.minezero": "MineZero Keybinds",
   "key.minezero.example_action": "Example Action",


### PR DESCRIPTION
# PR#<issue-number> <!-- ex: PR#100-->

## Type of Changes

<!-- Put an x in the checkboxs that apply. ex: - [x] Bug fix -->

- [ ] Bug fix
- [ ] New feature

## Description

<!-- Describe your changes here -->
<!-- What does this PR do/fix? -->

## How has this been tested?

<!-- List reproduction steps -->
<!-- ex:
    1. Navigate to login page
    2. Enter credentials
        2a. Valid Credentials -> information authenticated and user redirected to dashboard
        2b. Invalid Credentials -> error message displayed and user is NOT redirected
    ...
-->

## Screenshots (if necessary)

## Additional Information (if necessary)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `setCheckpointOnWorldCreation` gamerule gating initial checkpoint creation and a listener to cache block entity (including double chest) state on first interaction; bumps version to 1.0.10.
> 
> - **Checkpoint/Gameplay**:
>   - Add gamerule `setCheckpointOnWorldCreation` in `ModGameRules` with localization entries.
>   - Update `MineZero.onPlayerLogin` to set the initial checkpoint only when this gamerule is enabled.
> - **World State Caching**:
>   - Introduce `event/BlockEntityChangeListener` to cache `BlockEntity` NBT and dimension index in `WorldData` on first post-checkpoint interaction.
>   - Special handling for double chests: also caches the connected half.
> - **Version**:
>   - Bump mod version to `1.0.10` in `gradle.properties` and `mods.toml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 435b2411e9075283bb4f827fe72c6242b48d5f8d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->