### PR TITLE
Add multiplayer rbd

### DIFF
--- a/MOD_DESC.md
+++ b/MOD_DESC.md
@@ -60,3 +60,12 @@ While _MineZero_ focuses on **Return by Death**, _Re:Zero Experience_ brings in 
 
 *   **Usage:** `/gamerule fluteCooldownDuration <seconds>`
 *   **Description:** Sets the duration (in seconds) of the cooldown period for the Artifact Flute.
+* 
+### Random Anchor
+
+*   **Usage:** `/gamerule enableRandomAnchor false`
+*   **Description:** Enables wether the checkpoint should be set by random players.
+
+### All Players Return By Death
+*   **Usage:** `/gamerule enableAllPlayersRBD false`
+*   **Description:** Enables wether the checkpoint shall be restored if any player dies (true) or only when the anchor dies (false).

--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ This repository maintains multiple branches for different versions and mod loade
 
 ---
 
+## Version Status
+
+| Branch           | Loader    | MC Version | Status     |
+|------------------|-----------|------------|------------|
+| 1.20.1-forge     | Forge     | 1.20.1     | Released   |
+| 1.21.1-neoforge  | NeoForge  | 1.21.1     | Released   |
+| 1.21.1-fabric    | Fabric    | 1.21.1     | In Progress |
+| 1.12.2-forge     | Forge     | 1.12.2     | In Progress |
+
 ## Commands
 
 * `/setcheckpoint` → Sets the checkpoint for the executing player (requires OP level 2).

--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@
 
 
 
+## CurseForge
+
+Get releases on CurseForge: [MineZero — Return By Death](https://www.curseforge.com/minecraft/mc-mods/mine-zero-return-by-death)
+
+---
+
 ## Features
 
 * **Checkpoints**

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Get releases on CurseForge: [MineZero — Return By Death](https://www.curseforg
 * **Anchor Player System**
 
   * Only the **anchor player’s death** triggers a reset.
+    * This can be changed via the gamerule **"enableAllPlayersRBD"**
+    * Alternatively you can let the anchor be randomly chosen on each new checkpoint with **"enableRandomAnchor"**
   * The anchor player is set automatically when they create a checkpoint.
 
 * **World Reset on Death**

--- a/src/main/java/boomcow/minezero/ModGameRules.java
+++ b/src/main/java/boomcow/minezero/ModGameRules.java
@@ -57,4 +57,13 @@ public class ModGameRules {
         // Default: true
         public static final GameRules.Key<BooleanValue> SET_CHECKPOINT_ON_WORLD_CREATION = GameRules.register(
                         "setCheckpointOnWorldCreation", GameRules.Category.PLAYER, GameRules.BooleanValue.create(true));
+
+        // Enable wether the mod should randomly choose an anchor on each
+        public static final GameRules.Key<BooleanValue> RANDOM_ANCHOR_ENABLED = GameRules.register(
+                "enableRandomAnchor", GameRules.Category.PLAYER, GameRules.BooleanValue.create(false));
+
+        // Enable wether all players on the Server should be an anchor
+        public static final GameRules.Key<BooleanValue> ALL_PLAYERS_RBD = GameRules.register(
+                "enableAllPlayersRBD", GameRules.Category.PLAYER, GameRules.BooleanValue.create(false));
+
 }

--- a/src/main/java/boomcow/minezero/checkpoint/CheckpointData.java
+++ b/src/main/java/boomcow/minezero/checkpoint/CheckpointData.java
@@ -436,3 +436,4 @@ public class CheckpointData extends SavedData {
 
 
 }
+

--- a/src/main/java/boomcow/minezero/event/CheckpointTicker.java
+++ b/src/main/java/boomcow/minezero/event/CheckpointTicker.java
@@ -6,12 +6,20 @@ import boomcow.minezero.checkpoint.CheckpointManager;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.server.players.PlayerList;
+import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.jmx.Server;
 
 @Mod.EventBusSubscriber
 public class CheckpointTicker {
@@ -85,18 +93,31 @@ public class CheckpointTicker {
             return;
         }
 
+        Random random = new Random();
+
         if (currentTick - lastCheckpointTick >= nextCheckpointInterval) {
             CheckpointData data = CheckpointData.get(level);
             if (data.getAnchorPlayerUUID() == null) {
                 if (!server.getPlayerList().getPlayers().isEmpty()) {
                     ServerPlayer firstPlayer = server.getPlayerList().getPlayers().get(0);
                     data.setAnchorPlayerUUID(firstPlayer.getUUID());
-
                 } else {
                     LOGGER.warn("No players online to set as anchor.");
                     return;
                 }
+
             }
+
+            // Random anchor logic
+            if (level.getGameRules().getRule(ModGameRules.RANDOM_ANCHOR_ENABLED).get()) {
+                int playerAmount = server.getPlayerCount();
+                int randomInt = random.nextInt(playerAmount);
+                ServerPlayer randomPlayer = server.getPlayerList().getPlayers().get(randomInt);
+                data.setAnchorPlayerUUID(randomPlayer.getUUID());
+                LOGGER.debug("Player {} is set as new Anchor.", randomPlayer.getName());
+            }
+
+
             ServerPlayer anchorPlayer = server.getPlayerList().getPlayer(data.getAnchorPlayerUUID());
             if (anchorPlayer != null) {
 

--- a/src/main/java/boomcow/minezero/event/CheckpointTicker.java
+++ b/src/main/java/boomcow/minezero/event/CheckpointTicker.java
@@ -6,20 +6,14 @@ import boomcow.minezero.checkpoint.CheckpointManager;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.server.players.PlayerList;
-import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
-import java.util.List;
-import java.util.Map;
 import java.util.Random;
-import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.jmx.Server;
 
 @Mod.EventBusSubscriber
 public class CheckpointTicker {
@@ -32,6 +26,7 @@ public class CheckpointTicker {
     private static boolean randomIntervalSelected = false;
 
     private static int intervalTicks = 0;
+    public static Random random = new Random();
 
     @SubscribeEvent
     public static void onServerTick(TickEvent.ServerTickEvent event) {
@@ -92,8 +87,6 @@ public class CheckpointTicker {
             lastCheckpointTick = currentTick;
             return;
         }
-
-        Random random = new Random();
 
         if (currentTick - lastCheckpointTick >= nextCheckpointInterval) {
             CheckpointData data = CheckpointData.get(level);

--- a/src/main/java/boomcow/minezero/event/DeathEventHandler.java
+++ b/src/main/java/boomcow/minezero/event/DeathEventHandler.java
@@ -1,6 +1,7 @@
 package boomcow.minezero.event;
 
 import boomcow.minezero.ConfigHandler;
+import boomcow.minezero.ModGameRules;
 import boomcow.minezero.ModSoundEvents;
 import boomcow.minezero.checkpoint.CheckpointData;
 import boomcow.minezero.checkpoint.CheckpointManager;
@@ -32,7 +33,12 @@ public class DeathEventHandler {
                 CheckpointTicker.lastCheckpointTick = server.getTickCount();
             }
 
-            if (data.getAnchorPlayerUUID() == null || !player.getUUID().equals(data.getAnchorPlayerUUID())) {
+            if (data.getAnchorPlayerUUID() == null
+                    ||
+                (!player.getUUID().equals(data.getAnchorPlayerUUID()) &&
+                        !level.getGameRules().getRule(ModGameRules.ALL_PLAYERS_RBD).get())
+                ) // Check wether gamerule is enabled, if not, it does not matter who dies --> activate your logic anyway
+            {
 
                 return;
             }


### PR DESCRIPTION
# PR Adding more functionality to multiplayer

## Type of Changes

- Added 2 new gamerules: **enableAllPlayersRBD and enableRandomAnchor**
- Added simple functionality to when the gamerules are active or not
- **enableAllPlayersRBD**: Activates RBD when any player dies
- **enableRandomAnchor**: Chooses an anchor randomly on each checkpoint set

## Description

Better multiplayer functionality, allows people to play together on servers and make it more challanging / entertaining since every player needs to be careful of not dying, not just the anchor

If you want more randomness, you can activate the random anchor functionality which will choose an random anchor each time, in one checkpoint I may be the one who should be careful of not dying, in another my friend etc.

Both these things are not really canon re:zero

## How has this been tested?

gradle runClient
gradle runClientAlt
gradle runServer

I killed myself, then I killed the other client, both caused the RBD functionality to activate when the gamerule was enabled. Random anchor was tested via logs in the server, printing out the player name of the anchor on each checkpoint set.