### PR TITLE
Save and restore player air supply in checkpoints

### DIFF
--- a/src/main/java/boomcow/minezero/MineZero.java
+++ b/src/main/java/boomcow/minezero/MineZero.java
@@ -162,6 +162,7 @@ public class MineZero {
             pDataForNewPlayer.experienceLevel = player.experienceLevel;
             pDataForNewPlayer.experienceProgress = player.experienceProgress;
             pDataForNewPlayer.fireTicks = player.getRemainingFireTicks();
+            pDataForNewPlayer.airSupply = player.getAirSupply();
 
             BlockPos spawn = player.getRespawnPosition();
             ResourceKey<Level> spawnDim = player.getRespawnDimension();

--- a/src/main/java/boomcow/minezero/checkpoint/CheckpointManager.java
+++ b/src/main/java/boomcow/minezero/checkpoint/CheckpointManager.java
@@ -78,6 +78,7 @@ public class CheckpointManager {
             pdataObject.experienceLevel = player.experienceLevel;
             pdataObject.experienceProgress = player.experienceProgress;
             pdataObject.fireTicks = player.getRemainingFireTicks();
+            pdataObject.airSupply = player.getAirSupply();
 
             BlockPos spawn = player.getRespawnPosition();
             ResourceKey<Level> spawnDim = player.getRespawnDimension();
@@ -412,6 +413,7 @@ public class CheckpointManager {
 
 
                     player.setRemainingFireTicks(pdata.fireTicks);
+                    player.setAirSupply(pdata.airSupply);
                     if (pdata.gameMode != null) {
                         switch (pdata.gameMode.toLowerCase()) {
                             case "survival" -> player.setGameMode(net.minecraft.world.level.GameType.SURVIVAL);

--- a/src/main/java/boomcow/minezero/checkpoint/PlayerData.java
+++ b/src/main/java/boomcow/minezero/checkpoint/PlayerData.java
@@ -28,6 +28,7 @@ public class PlayerData {
     public int experienceLevel;
     public float experienceProgress;
     public int fireTicks;
+    public int airSupply;
     public ResourceKey<Level> dimension;
     public String gameMode;
     public double spawnX;
@@ -54,6 +55,7 @@ public class PlayerData {
         tag.putFloat("Health", health);
         tag.putInt("Hunger", hunger);
         tag.putInt("FireTicks", fireTicks);
+        tag.putInt("AirSupply", airSupply);
         tag.putString("GameMode", gameMode);
         tag.putInt("ExperienceLevel", experienceLevel);
         tag.putFloat("ExperienceProgress", experienceProgress);
@@ -99,6 +101,7 @@ public class PlayerData {
         data.health = tag.getFloat("Health");
         data.hunger = tag.getInt("Hunger");
         data.fireTicks = tag.getInt("FireTicks");
+        data.airSupply = tag.getInt("AirSupply");
         data.spawnX = tag.getDouble("SpawnX");
         data.spawnY = tag.getDouble("SpawnY");
         data.spawnZ = tag.getDouble("SpawnZ");


### PR DESCRIPTION
# PR#<issue-number> <!-- e.g. PR#100 -->

## Type of Changes

<!-- Put an x in the checkboxes that apply. e.g. - [x] Bug fix -->

- [x] Bug fix
- [ ] New feature

## Description

Fixed an issue where MineZero did not support saving and restoring the player's `airSupply` (air bubbles). Previously, only the player's position, health, and inventory were saved, but not the remaining air. After this fix, `airSupply` is now properly captured during checkpoint saving and restored upon death return.

## How has this been tested?

1. Go underwater and set a checkpoint (e.g., at a certain depth).
2. Drown the player underwater.
3. Trigger death return (e.g., by using an anchor player or automatic regression).
4. Observe that the player's air supply is correctly restored to the checkpoint value, preventing continuous suffocation loops.

**Before the fix:** After drowning, the player would respawn with zero or incorrect air supply and immediately start drowning again, making it impossible to escape if the water was deep enough.

**After the fix:** The player's air supply is fully restored, allowing them to swim up safely.

## Screenshots (if necessary)

N/A

## Additional Information (if necessary)

This fix is especially important for underwater exploration or maps with deep water mechanics. Without it, players could be permanently stuck in a death loop after drowning.