### PR TITLE
Fixed a bug where reward chests were not correctly rolled back.

### DIFF
--- a/src/main/java/boomcow/minezero/event/NonPlayerChangeHandler.java
+++ b/src/main/java/boomcow/minezero/event/NonPlayerChangeHandler.java
@@ -4,6 +4,8 @@ import boomcow.minezero.checkpoint.CheckpointData;
 import boomcow.minezero.checkpoint.WorldData;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.Tag;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.Explosion;
@@ -11,12 +13,15 @@ import net.minecraft.world.level.block.BedBlock;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.DoorBlock;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BedPart;
 import net.minecraft.world.level.block.state.properties.DoubleBlockHalf;
+import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.neoforge.event.level.BlockEvent;
+import net.neoforged.neoforge.event.level.ChunkEvent;
 import net.neoforged.neoforge.event.level.ExplosionEvent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -142,5 +147,28 @@ public class NonPlayerChangeHandler {
     }
 
 
+    @SubscribeEvent
+    public static void onChunkLoad(ChunkEvent.Load event) {
+        if (!(event.getLevel() instanceof ServerLevel level)) return;
 
+        CheckpointData data = CheckpointData.get(level);
+        if (data.getAnchorPlayerUUID() == null) return;
+
+        WorldData worldData = data.getWorldData();
+        if (worldData == null) return;
+
+        int dimIndex = WorldData.getDimensionIndex(level.dimension());
+
+        if (!(event.getChunk() instanceof LevelChunk levelChunk)) return;
+
+        for (BlockEntity be : levelChunk.getBlockEntities().values()) {
+            if (be == null || be.isRemoved()) continue;
+            CompoundTag nbt = be.saveWithFullMetadata(level.registryAccess());
+            if (nbt.contains("LootTable", Tag.TAG_STRING)) {
+                BlockPos pos = be.getBlockPos().immutable();
+                worldData.saveBlockEntity(pos, nbt);
+                worldData.blockDimensionIndices.put(pos, dimIndex);
+            }
+        }
+    }
 }


### PR DESCRIPTION
# PR#<issue-number> <!-- ex: PR#100-->

## Type of Changes

<!-- Put an x in the checkboxs that apply. ex: - [x] Bug fix -->

- [x] Bug fix
- [ ] New feature

## Description

Fixed a bug where reward chests (chests generated with a LootTable + LootTableSeed) were not correctly rolled back after a death return.

**Root cause:** When a player triggered a checkpoint save, then explored newly generated chunks and opened a reward chest, the chest's LootTable and LootTableSeed were removed after unpacking (becoming a normal chest). If that chunk later unloaded and a death return occurred, the saved checkpoint only contained the empty chest state (without LootTable), causing the reward chest to not regenerate its loot after rollback.

**Fix:** During checkpoint saving, reward chests that still have LootTable + LootTableSeed (i.e., not yet opened by any player) are saved with full metadata using `saveWithFullMetadata()`. Their NBT is stored in `worldData.blockEntityData`. When a death return triggers `restoreCheckpoint`, `blockEntity.loadWithComponents(savedNbt)` restores the chest with its original LootTable and LootTableSeed. When the player opens it again, `unpackLootTable()` regenerates the exact same loot.

## How has this been tested?

1. Set a checkpoint **before** a reward chest is generated (or far away from any ungenerated structure).
2. Travel to a new chunk that contains a reward chest (e.g., shipwreck, dungeon, etc.).
3. Open the reward chest and take some items (this converts it from a loot chest to a normal chest).
4. Move far away to let the chunk unload
5. Trigger a death return
6. Return to the reward chest location and open it again.

**Before the fix:** The chest would be empty (no loot regenerated).  
**After the fix:** The chest regenerates the exact same loot as originally generated, and the rollback works correctly.

Additional test case:
- Set checkpoint before reward chest appears, open chest, take items, trigger death return **without** chunk unloading → also works correctly.

## Screenshots (if necessary)

N/A

## Additional Information (if necessary)

This fix ensures that reward chests are treated as part of the persistent world state during checkpoint save/restore, preventing loot loss when death return occurs across chunk unloading boundaries.