### PR TITLE
Miscellaneous changes PR

### DIFF
--- a/src/main/java/boomcow/minezero/checkpoint/CheckpointManager.java
+++ b/src/main/java/boomcow/minezero/checkpoint/CheckpointManager.java
@@ -6,10 +6,12 @@ import net.minecraft.advancements.AdvancementProgress;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.protocol.game.ClientboundGameEventPacket;
+import net.minecraft.network.protocol.game.ClientboundStopSoundPacket;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.ServerAdvancementManager;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.entity.*;
 import net.minecraft.world.entity.boss.enderdragon.EndCrystal;
@@ -72,6 +74,9 @@ public class CheckpointManager {
 
             pdata.health = player.getHealth();
             pdata.hunger = player.getFoodData().getFoodLevel();
+            pdata.saturation = player.getFoodData().getSaturationLevel();
+            pdata.exhaustion = player.getFoodData().getExhaustionLevel();
+            pdata.airsupply = player.getAirSupply();
             pdata.experienceLevel = player.experienceLevel;
             pdata.experienceProgress = player.experienceProgress;
 
@@ -380,6 +385,9 @@ public class CheckpointManager {
                     }
 
                     player.getFoodData().setFoodLevel(pdata.hunger);
+                    player.getFoodData().setSaturation(pdata.saturation);
+                    player.getFoodData().setExhaustion(pdata.exhaustion);
+                    player.setAirSupply(pdata.airsupply);
                     player.setExperienceLevels(pdata.experienceLevel);
                     player.experienceProgress = pdata.experienceProgress;
 
@@ -535,6 +543,12 @@ public class CheckpointManager {
                 if (level.getBlockState(firePos).getBlock() == Blocks.FIRE) {
                     level.setBlockAndUpdate(firePos, Blocks.AIR.defaultBlockState());
                 }
+            }
+
+            ClientboundStopSoundPacket stopMusicPacket =
+                    new ClientboundStopSoundPacket(null, SoundSource.MUSIC);
+            for (ServerPlayer player : level.getServer().getPlayerList().getPlayers()) {
+                player.connection.send(stopMusicPacket);
             }
 
             long endTime = System.nanoTime();

--- a/src/main/java/boomcow/minezero/checkpoint/CheckpointManager.java
+++ b/src/main/java/boomcow/minezero/checkpoint/CheckpointManager.java
@@ -6,6 +6,7 @@ import net.minecraft.advancements.AdvancementProgress;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.protocol.game.ClientboundGameEventPacket;
+import net.minecraft.network.protocol.game.ClientboundSetCarriedItemPacket;
 import net.minecraft.network.protocol.game.ClientboundStopSoundPacket;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.ServerAdvancementManager;
@@ -82,6 +83,7 @@ public class CheckpointManager {
 
             logger.info("Player XP: " + player.totalExperience);
             pdata.fireTicks = player.getRemainingFireTicks();
+            pdata.selectedHotbarSlot = player.getInventory().selected;
 
             BlockPos spawn = player.getRespawnPosition();
             ResourceKey<Level> spawnDim = player.getRespawnDimension();
@@ -453,6 +455,10 @@ public class CheckpointManager {
                     for (int i = 0; i < pdata.inventory.size(); i++) {
                         player.getInventory().setItem(i, pdata.inventory.get(i));
                     }
+                    int selectedHotbarSlot = Math.max(0, Math.min(8, pdata.selectedHotbarSlot));
+                    player.getInventory().selected = selectedHotbarSlot;
+                    player.connection.send(new ClientboundSetCarriedItemPacket(selectedHotbarSlot));
+                    player.containerMenu.broadcastChanges();
                 }
             }
 

--- a/src/main/java/boomcow/minezero/checkpoint/PlayerData.java
+++ b/src/main/java/boomcow/minezero/checkpoint/PlayerData.java
@@ -30,6 +30,7 @@ public class PlayerData {
     public int experienceLevel;
     public float experienceProgress;
     public int fireTicks;
+    public int selectedHotbarSlot;
     public ResourceKey<Level> dimension;
     public List<ItemStack> inventory = new ArrayList<>();
     public String gameMode;
@@ -61,6 +62,7 @@ public class PlayerData {
         tag.putInt("AirSupply", airsupply);
 
         tag.putInt("FireTicks", fireTicks);
+        tag.putInt("SelectedHotbarSlot", selectedHotbarSlot);
         tag.putString("GameMode", gameMode);
         tag.putInt("ExperienceLevel", experienceLevel);
         tag.putFloat("ExperienceProgress", experienceProgress);
@@ -118,6 +120,7 @@ public class PlayerData {
         data.exhaustion = tag.getFloat("Exhaustion");
         data.airsupply = tag.getInt("AirSupply");
         data.fireTicks = tag.getInt("FireTicks");
+        data.selectedHotbarSlot = tag.contains("SelectedHotbarSlot") ? tag.getInt("SelectedHotbarSlot") : 0;
 
         data.spawnX = tag.getDouble("SpawnX");
         data.spawnY = tag.getDouble("SpawnY");

--- a/src/main/java/boomcow/minezero/checkpoint/PlayerData.java
+++ b/src/main/java/boomcow/minezero/checkpoint/PlayerData.java
@@ -24,6 +24,9 @@ public class PlayerData {
     public float pitch;
     public float health;
     public int hunger;
+    public float saturation;
+    public float exhaustion;
+    public int airsupply;
     public int experienceLevel;
     public float experienceProgress;
     public int fireTicks;
@@ -53,6 +56,9 @@ public class PlayerData {
         tag.putFloat("Pitch", pitch);
         tag.putFloat("Health", health);
         tag.putInt("Hunger", hunger);
+        tag.putFloat("Saturation", saturation);
+        tag.putFloat("Exhaustion", exhaustion);
+        tag.putInt("AirSupply", airsupply);
 
         tag.putInt("FireTicks", fireTicks);
         tag.putString("GameMode", gameMode);
@@ -108,6 +114,9 @@ public class PlayerData {
         data.pitch = tag.getFloat("Pitch");
         data.health = tag.getFloat("Health");
         data.hunger = tag.getInt("Hunger");
+        data.saturation = tag.getFloat("Saturation");
+        data.exhaustion = tag.getFloat("Exhaustion");
+        data.airsupply = tag.getInt("AirSupply");
         data.fireTicks = tag.getInt("FireTicks");
 
         data.spawnX = tag.getDouble("SpawnX");

--- a/src/main/java/boomcow/minezero/event/DeathEventHandler.java
+++ b/src/main/java/boomcow/minezero/event/DeathEventHandler.java
@@ -51,9 +51,9 @@ public class DeathEventHandler {
 
             String chime = ConfigHandler.getDeathChime();
             if ("CLASSIC".equalsIgnoreCase(chime)) {
-                playClassicChime(player);
+                playClassicChime(level.getServer());
             } else if ("ALTERNATE".equalsIgnoreCase(chime)) {
-                playAlternateChime(player);
+                playAlternateChime(level.getServer());
             }
 
         } catch (Exception e) {
@@ -62,29 +62,33 @@ public class DeathEventHandler {
         }
     }
 
-    private void playClassicChime(ServerPlayer player) {
+    private void playClassicChime(MinecraftServer server) {
 
         Logger logger = LogManager.getLogger();
         logger.debug("Playing classic chime");
         ClientboundStopSoundPacket stopSoundPacket = new ClientboundStopSoundPacket(
                 new ResourceLocation("minezero", "death_chime"),
                 SoundSource.PLAYERS);
-        player.connection.send(stopSoundPacket);
 
-        player.playNotifySound(ModSoundEvents.DEATH_CHIME.get(), SoundSource.PLAYERS, 0.8F, 1.0F);
+        for (ServerPlayer player : server.getPlayerList().getPlayers()) {
+            player.connection.send(stopSoundPacket);
+            player.playNotifySound(ModSoundEvents.DEATH_CHIME.get(), SoundSource.PLAYERS, 0.8F, 1.0F);
+        }
 
     }
 
-    private void playAlternateChime(ServerPlayer player) {
+    private void playAlternateChime(MinecraftServer server) {
 
         Logger logger = LogManager.getLogger();
         logger.debug("Playing alternate chime");
         ClientboundStopSoundPacket stopSoundPacket = new ClientboundStopSoundPacket(
                 new ResourceLocation("minezero", "alt_death_chime"),
                 SoundSource.PLAYERS);
-        player.connection.send(stopSoundPacket);
 
-        player.playNotifySound(ModSoundEvents.ALT_DEATH_CHIME.get(), SoundSource.PLAYERS, 0.8F, 1.0F);
+        for (ServerPlayer player : server.getPlayerList().getPlayers()) {
+            player.connection.send(stopSoundPacket);
+            player.playNotifySound(ModSoundEvents.ALT_DEATH_CHIME.get(), SoundSource.PLAYERS, 0.8F, 1.0F);
+        }
 
     }
 


### PR DESCRIPTION
# PR#1

## Type of Changes

- [ ] Bug fix
- [x] New feature

## Description

Adds RBD support for saturation, exhaustion, and oxygen levels, as well as selected hotbar slot. Also halts ingame music for all players whenever RBD is activated, and plays the RBD chime for all players, rather than just subaru (to avoid confusion in multiplayer)

## How has this been tested?

Ran tests in a new singleplayer world using appleskin mod to make sure the saturation and exhaustion saving/loading was working and used Essential mod to test multiplayer mechanics with no issue.

https://github.com/user-attachments/assets/3a92f5d6-4987-456a-b3a5-3f74541040d3

(Note the halting of ingame music, reversion of hunger exhaustion level, and hotbar being forced to slot 5)

## Additional Information

A few things I'd like to add - I understand if other players not being able to hear the jingle is an intended mechanic. If that's the case, I'd like to suggest a configurable setting to either have all players or only the anchor hear the RBD sound effects. I'd also like to apologize for not first creating a feature request. I got well into making these changes for my own use before deciding to submit a pull request after the fact, so it made more sense to just submit it as-is. Apologies