### PR TITLE
miscellaneous additions

### DIFF
--- a/src/main/java/boomcow/minezero/checkpoint/CheckpointManager.java
+++ b/src/main/java/boomcow/minezero/checkpoint/CheckpointManager.java
@@ -6,10 +6,13 @@ import net.minecraft.advancements.AdvancementProgress;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.protocol.game.ClientboundGameEventPacket;
+import net.minecraft.network.protocol.game.ClientboundSetCarriedItemPacket;
+import net.minecraft.network.protocol.game.ClientboundStopSoundPacket;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.ServerAdvancementManager;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.entity.*;
 import net.minecraft.world.entity.boss.enderdragon.EndCrystal;
@@ -72,11 +75,15 @@ public class CheckpointManager {
 
             pdata.health = player.getHealth();
             pdata.hunger = player.getFoodData().getFoodLevel();
+            pdata.saturation = player.getFoodData().getSaturationLevel();
+            pdata.exhaustion = player.getFoodData().getExhaustionLevel();
+            pdata.airSupply = player.getAirSupply();
             pdata.experienceLevel = player.experienceLevel;
             pdata.experienceProgress = player.experienceProgress;
 
             logger.info("Player XP: " + player.totalExperience);
             pdata.fireTicks = player.getRemainingFireTicks();
+            pdata.selectedHotbarSlot = player.getInventory().selected;
 
             BlockPos spawn = player.getRespawnPosition();
             ResourceKey<Level> spawnDim = player.getRespawnDimension();
@@ -380,6 +387,9 @@ public class CheckpointManager {
                     }
 
                     player.getFoodData().setFoodLevel(pdata.hunger);
+                    player.getFoodData().setSaturation(pdata.saturation);
+                    player.getFoodData().setExhaustion(pdata.exhaustion);
+                    player.setAirSupply(pdata.airSupply);
                     player.setExperienceLevels(pdata.experienceLevel);
                     player.experienceProgress = pdata.experienceProgress;
 
@@ -445,6 +455,10 @@ public class CheckpointManager {
                     for (int i = 0; i < pdata.inventory.size(); i++) {
                         player.getInventory().setItem(i, pdata.inventory.get(i));
                     }
+                    int selectedHotbarSlot = Math.max(0, Math.min(8, pdata.selectedHotbarSlot));
+                    player.getInventory().selected = selectedHotbarSlot;
+                    player.connection.send(new ClientboundSetCarriedItemPacket(selectedHotbarSlot));
+                    player.containerMenu.broadcastChanges();
                 }
             }
 
@@ -537,6 +551,12 @@ public class CheckpointManager {
                 }
             }
 
+            ClientboundStopSoundPacket stopMusicPacket =
+                    new ClientboundStopSoundPacket(null, SoundSource.MUSIC);
+            for (ServerPlayer player : level.getServer().getPlayerList().getPlayers()) {
+                player.connection.send(stopMusicPacket);
+            }
+
             long endTime = System.nanoTime();
             long durationMs = (endTime - startTime) / 1_000_000;
             logger.debug("Restoring states took {} ms", durationMs);
@@ -546,5 +566,4 @@ public class CheckpointManager {
             e.printStackTrace();
         }
     }
-
 }

--- a/src/main/java/boomcow/minezero/checkpoint/PlayerData.java
+++ b/src/main/java/boomcow/minezero/checkpoint/PlayerData.java
@@ -24,9 +24,13 @@ public class PlayerData {
     public float pitch;
     public float health;
     public int hunger;
+    public float saturation;
+    public float exhaustion;
+    public int airSupply;
     public int experienceLevel;
     public float experienceProgress;
     public int fireTicks;
+    public int selectedHotbarSlot;
     public ResourceKey<Level> dimension;
     public List<ItemStack> inventory = new ArrayList<>();
     public String gameMode;
@@ -53,8 +57,12 @@ public class PlayerData {
         tag.putFloat("Pitch", pitch);
         tag.putFloat("Health", health);
         tag.putInt("Hunger", hunger);
+        tag.putFloat("Saturation", saturation);
+        tag.putFloat("Exhaustion", exhaustion);
+        tag.putInt("AirSupply", airSupply);
 
         tag.putInt("FireTicks", fireTicks);
+        tag.putInt("SelectedHotbarSlot", selectedHotbarSlot);
         tag.putString("GameMode", gameMode);
         tag.putInt("ExperienceLevel", experienceLevel);
         tag.putFloat("ExperienceProgress", experienceProgress);
@@ -108,7 +116,11 @@ public class PlayerData {
         data.pitch = tag.getFloat("Pitch");
         data.health = tag.getFloat("Health");
         data.hunger = tag.getInt("Hunger");
+        data.saturation = tag.getFloat("Saturation");
+        data.exhaustion = tag.getFloat("Exhaustion");
+        data.airSupply = tag.getInt("AirSupply");
         data.fireTicks = tag.getInt("FireTicks");
+        data.selectedHotbarSlot = tag.contains("SelectedHotbarSlot") ? tag.getInt("SelectedHotbarSlot") : 0;
 
         data.spawnX = tag.getDouble("SpawnX");
         data.spawnY = tag.getDouble("SpawnY");

--- a/src/main/java/boomcow/minezero/event/DeathEventHandler.java
+++ b/src/main/java/boomcow/minezero/event/DeathEventHandler.java
@@ -35,11 +35,11 @@ public class DeathEventHandler {
 
             if (data.getAnchorPlayerUUID() == null
                     ||
-                (!player.getUUID().equals(data.getAnchorPlayerUUID()) &&
-                        !level.getGameRules().getRule(ModGameRules.ALL_PLAYERS_RBD).get())
-                ) // Check wether gamerule is enabled, if not, it does not matter who dies --> activate your logic anyway
+                    (!player.getUUID().equals(data.getAnchorPlayerUUID()) &&
+                            !level.getGameRules().getRule(ModGameRules.ALL_PLAYERS_RBD).get())
+                    ) // Check whether gamerule is enabled, if not, it does not matter who dies --> activate your logic anyway
             {
-
+                
                 return;
             }
 
@@ -57,9 +57,9 @@ public class DeathEventHandler {
 
             String chime = ConfigHandler.getDeathChime();
             if ("CLASSIC".equalsIgnoreCase(chime)) {
-                playClassicChime(player);
+                playClassicChime(level.getServer());
             } else if ("ALTERNATE".equalsIgnoreCase(chime)) {
-                playAlternateChime(player);
+                playAlternateChime(level.getServer());
             }
 
         } catch (Exception e) {
@@ -68,29 +68,33 @@ public class DeathEventHandler {
         }
     }
 
-    private void playClassicChime(ServerPlayer player) {
+    private void playClassicChime(MinecraftServer server) {
 
         Logger logger = LogManager.getLogger();
         logger.debug("Playing classic chime");
         ClientboundStopSoundPacket stopSoundPacket = new ClientboundStopSoundPacket(
                 new ResourceLocation("minezero", "death_chime"),
                 SoundSource.PLAYERS);
-        player.connection.send(stopSoundPacket);
 
-        player.playNotifySound(ModSoundEvents.DEATH_CHIME.get(), SoundSource.PLAYERS, 0.8F, 1.0F);
+        for (ServerPlayer player : server.getPlayerList().getPlayers()) {
+            player.connection.send(stopSoundPacket);
+            player.playNotifySound(ModSoundEvents.DEATH_CHIME.get(), SoundSource.PLAYERS, 0.8F, 1.0F);
+        }
 
     }
 
-    private void playAlternateChime(ServerPlayer player) {
+    private void playAlternateChime(MinecraftServer server) {
 
         Logger logger = LogManager.getLogger();
         logger.debug("Playing alternate chime");
         ClientboundStopSoundPacket stopSoundPacket = new ClientboundStopSoundPacket(
                 new ResourceLocation("minezero", "alt_death_chime"),
                 SoundSource.PLAYERS);
-        player.connection.send(stopSoundPacket);
 
-        player.playNotifySound(ModSoundEvents.ALT_DEATH_CHIME.get(), SoundSource.PLAYERS, 0.8F, 1.0F);
+        for (ServerPlayer player : server.getPlayerList().getPlayers()) {
+            player.connection.send(stopSoundPacket);
+            player.playNotifySound(ModSoundEvents.ALT_DEATH_CHIME.get(), SoundSource.PLAYERS, 0.8F, 1.0F);
+        }
 
     }
 


### PR DESCRIPTION
# PR#1

## Type of Changes

- [ ] Bug fix
- [x] New feature

## Description

Adds RBD support for saturation, exhaustion, and oxygen levels, as well as selected hotbar slot. Also halts ingame music for all players whenever RBD is activated, and plays the RBD chime for all players, rather than just subaru (to avoid confusion in multiplayer)

## How has this been tested?

Ran tests in a new singleplayer world using appleskin mod to make sure the saturation and exhaustion saving/loading was working and used Essential mod to test multiplayer mechanics with no issue.

https://github.com/user-attachments/assets/3a92f5d6-4987-456a-b3a5-3f74541040d3

(Note the halting of ingame music, reversion of hunger exhaustion level, and hotbar being forced to slot 5)

## Additional Information

A few things I'd like to add - I understand if other players not being able to hear the jingle is an intended mechanic. If that's the case, I'd like to suggest a configurable setting to either have all players or only the anchor hear the RBD sound effects. I'd also like to apologize for not first creating a feature request. I got well into making these changes for my own use before deciding to submit a pull request after the fact, so it made more sense to just submit it as-is. Apologies.

P.S. Sorry for having to send this in twice! I was accidentally working off of main rather than forge 1.20.1 before.